### PR TITLE
Read .api_key inside test function

### DIFF
--- a/src/test/test_GoogleGeocoder.py
+++ b/src/test/test_GoogleGeocoder.py
@@ -16,9 +16,9 @@ def read_contents(*names, **kwargs):
         encoding=kwargs.get("encoding", "utf8")
     ).read()
 
-api_key = read_contents(os.path.dirname(__file__), '.api_key')
 @pytest.mark.webtest
 def test_GoogleLocator_WithAPIKey():
+    api_key = read_contents(os.path.dirname(__file__), '.api_key')
     if api_key:
         locator = GoogleGeocoder(api_key=api_key)
         l = locator['Eiffel Tower']


### PR DESCRIPTION
Otherwise, the `.api_key` file is required even if the `test_GoogleLocator_WithAPIKey` test is not run.