### PR TITLE
Add LICENSE to PyPi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include notes.txt
 include src/test/*.py
 global-exclude *.pyc
 include monkeypatch.py
+include LICENSE


### PR DESCRIPTION
The license file should be included in the final tarball uploaded to PyPi