### PR TITLE
Add '__eq__' and '__hash__' methods to 'Location'

### DIFF
--- a/src/astral.py
+++ b/src/astral.py
@@ -581,6 +581,14 @@ class Location(object):
 
         self.url = ""
 
+    def __eq__(self, other):
+        if type(other) is Location:
+            return vars(self) == vars(other)
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(tuple(sorted(vars(self).items())))
+
     def __repr__(self):
         if self.region:
             _repr = "%s/%s" % (self.name, self.region)

--- a/src/test/test_Location.py
+++ b/src/test/test_Location.py
@@ -176,3 +176,21 @@ def test_Location_TzError():
     with raises(AttributeError):
         c = Location()
         c.tz = 1
+
+
+def test_Location_equality():
+    c1 = Location()
+    c2 = Location()
+    t = (c1, c2)
+    assert c1 == c2
+    assert len(set(t)) == 1
+
+    c1 = Location(["Oslo", "Norway", 59.9, 10.7, "Europe/Oslo", 0])
+    c2 = Location(["Oslo", "Norway", 59.9, 10.7, "Europe/Oslo", 0])
+    c3 = Location(["Stockholm", "Sweden", 59.3, 18, "Europe/Stockholm", 0])
+    t1 = (c1, c2)
+    t2 = (c1, c3)
+    assert c1 == c2
+    assert len(set(t1)) == 1
+    assert c1 != c3
+    assert len(set(t2)) == 2


### PR DESCRIPTION
This commit allows to do equality checks between Location objects, to easily know if they refer to the same location.
It also adds an '__hash__' method, allowing (for example) to remove duplicated locations with a set.

For example, it is now possible to dot the following, which is quite convenient when working with multiple locations.

```python
c1 = Location()
c2 = Location()
t = (c1, c2)
assert c1 == c2
assert len(set(t)) == 1
```

Indeed, it's just a suggestion. :)