### PR TITLE
Read .api_key inside test function

### DIFF
--- a/src/test/test_GoogleGeocoder.py
+++ b/src/test/test_GoogleGeocoder.py
@@ -10,17 +10,17 @@ def read_contents(*names, **kwargs):
         encoding=kwargs.get("encoding", "utf8")
     ).read()
 
-# 1st try to use the API_KEY environment variable that we encrypted
-# in our .travis.yml
-api_key = os.environ.get("API_KEY", None)
-if not api_key:
-	try:
-	    api_key = read_contents(os.path.dirname(__file__), '.api_key').strip()
-	except IOError as exc:
-	    raise ValueError("Google now requires an API key to be provided")
-
 @pytest.mark.webtest
 def test_GoogleLocator_WithAPIKey():
+    # 1st try to use the API_KEY environment variable that we encrypted
+    # in our .travis.yml
+    api_key = os.environ.get("API_KEY", None)
+    if not api_key:
+        try:
+            api_key = read_contents(os.path.dirname(__file__), '.api_key').strip()
+        except IOError as exc:
+            raise ValueError("Google now requires an API key to be provided")
+    
     locator = GoogleGeocoder(api_key=api_key)
     l = locator['Eiffel Tower']
     assert l is not None


### PR DESCRIPTION
Otherwise, the `.api_key` file is required even if the `test_GoogleLocator_WithAPIKey` test is not run.

Follow-up to https://github.com/sffjunkie/astral/pull/13.