### PR TITLE
Fix a typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 packages = [
 	{ include = "astral", from = "src"},
-	{ include = "doc", from = "src", format = "sdist"},
+	{ include = "docs", from = "src", format = "sdist"},
 	{ include = "test", from = "src", format = "sdist"},
 ]
 


### PR DESCRIPTION
poetry build command fails because there isn't `doc` directory. This PR fixes this problem.