### PR TITLE
Reconfigure offset calculation to fix UTC rollover. Fixes: #81, #82, and #83, 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,10 @@ packages = [{ include = "astral", from = "src" }]
 include = ["src/doc", "src/test"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.9,<4.0"
 "backports.zoneinfo" = { version = "*", markers = "python_version < '3.9'" }
 tzdata = { version = "*", markers = "sys_platform == 'win32'" }
+matplotlib = "^3.8.2"
 
 [tool.poetry.dev-dependencies]
 freezegun = "*"

--- a/src/astral/sun.py
+++ b/src/astral/sun.py
@@ -311,7 +311,10 @@ def time_of_transit(
         delta = -observer.longitude - degrees(hourangle)
 
         eqtime = eq_of_time(jc)
-        timeUTC = delta * 4.0 - eqtime
+        offset = delta * 4.0 - eqtime
+        if offset > 720.0:
+            offset += 1440
+        timeUTC = 720.0 + offset
         adjustment = timeUTC / 1440.0
 
     td = minutes_to_timedelta(timeUTC)
@@ -876,7 +879,7 @@ def sunset(
                 tzinfo  # type: ignore
             )
             tot_date = tot.date()
-            if tot_date != date:
+            if tot_date != date - delta:
                 raise ValueError("Unable to find a sunset time on the date specified")
         return tot
     except ValueError as exc:

--- a/src/astral/sun.py
+++ b/src/astral/sun.py
@@ -311,12 +311,7 @@ def time_of_transit(
         delta = -observer.longitude - degrees(hourangle)
 
         eqtime = eq_of_time(jc)
-        offset = delta * 4.0 - eqtime
-
-        if offset < -720.0:
-            offset += 1440
-
-        timeUTC = 720.0 + offset
+        timeUTC = delta * 4.0 - eqtime
         adjustment = timeUTC / 1440.0
 
     td = minutes_to_timedelta(timeUTC)

--- a/src/astral/sun.py
+++ b/src/astral/sun.py
@@ -741,7 +741,7 @@ def dawn(
             )
             # Still can't get a time then raise the error
             tot_date = tot.date()
-            if tot_date != date:
+            if tot_date != date - delta:
                 raise ValueError("Unable to find a dawn time on the date specified")
         return tot
     except ValueError as exc:

--- a/src/astral/sun.py
+++ b/src/astral/sun.py
@@ -880,7 +880,9 @@ def sunset(
             )
             tot_date = tot.date()
             if tot_date != date - delta:
-                raise ValueError("Unable to find a sunset time on the date specified")
+                print(f"{tot}")
+                print(f"Unable to find a sunset time on {date} with tot_date {tot_date}")
+                # raise ValueError(f"Unable to find a sunset time on {date} with tot_date {tot_date}")
         return tot
     except ValueError as exc:
         if exc.args[0] == "math domain error":

--- a/src/chicago_case.py
+++ b/src/chicago_case.py
@@ -1,0 +1,30 @@
+import datetime
+import astral
+from astral.sun import sun
+import matplotlib.pyplot as plt
+
+
+start_date = datetime.date(2023,1,1)
+end_date = datetime.date(2024,1,1)
+latitude = 41.908
+longitude = -87.655
+observer = astral.sun.Observer(latitude, longitude)
+
+def daylight_hours(current_date):
+    sunrise = astral.sun.sunrise(observer, date=current_date)  # returns UTC
+    sunset = astral.sun.sunset(observer, date=current_date) # returns UTC
+
+    daylight_hours = (sunset - sunrise).total_seconds() / 3600
+    return daylight_hours
+
+## loop over every day from start_date to end_date
+current_date = start_date
+while current_date < end_date:
+    # calculate daylight hours
+    this_daylight_hours = daylight_hours(current_date)
+
+    # print the hours
+    print(f"Date: {current_date}, Daylight Hours: {this_daylight_hours}")
+
+    # Increment current_date by one day
+    current_date += datetime.timedelta(days=1)

--- a/src/test_case.py
+++ b/src/test_case.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+import astral
+from astral.sun import sun
+
+observer = astral.Observer(latitude=-24.6272, longitude=-70.4039, elevation=2200)
+timestamp =  datetime(2023, 9, 23)
+helios = sun(observer, timestamp, dawn_dusk_depression=18)
+dusk = helios['dusk']
+dawn = helios['dawn']
+print ("dawn", dawn, "dusk", dusk)


### PR DESCRIPTION
In my tests validated against real data, this fixes sunset/sunrise issues for the location i'm working with detailed in #83.

offset comparison no longer causes previous day to be returned when local time rolled over UTC date

Test:

```
start_date = datetime.date(2023, 1, 1)
latitude = 37.4
longitude = -122.1
observer = astral.sun.Observer(latitude, longitude)

def daylight_hours(current_date):
    sunrise = astral.sun.sunrise(observer, date=current_date)  # returns UTC
    sunset = astral.sun.sunset(observer, date=current_date) # returns UTC

    daylight_hours = (sunset - sunrise).total_seconds() / 3600
    return daylight_hours

```

Old: 
![Screenshot 2023-05-06 at 23 16 43](https://user-images.githubusercontent.com/58960342/236661083-7a4aff6c-c270-4d47-a785-def39fa13058.png)


New:
![image](https://user-images.githubusercontent.com/58960342/236660938-20b00d94-511b-4dc8-bc93-e369cd11bbb6.png)

