### PR TITLE
Fix documentation of the night and twilight functions

### DIFF
--- a/src/astral/location.py
+++ b/src/astral/location.py
@@ -500,8 +500,8 @@ class Location:
         local: bool = True,
         observer_elevation: Elevation = 0.0,
     ) -> Tuple[datetime.datetime, datetime.datetime]:
-        """Calculates the night time (the time between astronomical dusk and
-        astronomical dawn of the next day)
+        """Calculates the night time (the time between civil dusk and civil dawn
+        of the next day)
 
         :param date: The date for which to calculate the start of the night time.
                      If no date is specified then the current date will be used.
@@ -539,8 +539,7 @@ class Location:
         """Returns the start and end times of Twilight in the UTC timezone when
         the sun is traversing in the specified direction.
 
-        This method defines twilight as being between the time
-        when the sun is at -6 degrees and sunrise/sunset.
+        This method defines twilight as being between civil dawn/dusk and sunrise/sunset.
 
         :param direction:  Determines whether the time is for the sun rising or setting.
                            Use ``astral.SUN_RISING`` or ``astral.SunDirection.SETTING``.

--- a/src/astral/sun.py
+++ b/src/astral/sun.py
@@ -1008,8 +1008,8 @@ def night(
 ) -> TimePeriod:
     """Calculate night start and end times.
 
-    Night is calculated to be between astronomical dusk on the
-    date specified and astronomical dawn of the next day.
+    Night is calculated to be between civil dusk on the
+    date specified and civil dawn of the next day.
 
     Args:
         observer:   Observer to calculate night for
@@ -1030,9 +1030,9 @@ def night(
     if date is None:
         date = today(tzinfo)  # type: ignore
 
-    start = dusk(observer, date, 6, tzinfo)
+    start = dusk(observer, date, Depression.CIVIL, tzinfo)
     tomorrow = date + datetime.timedelta(days=1)
-    end = dawn(observer, tomorrow, 6, tzinfo)
+    end = dawn(observer, tomorrow, Depression.CIVIL, tzinfo)
 
     return start, end
 
@@ -1046,8 +1046,7 @@ def twilight(
     """Returns the start and end times of Twilight
     when the sun is traversing in the specified direction.
 
-    This method defines twilight as being between the time
-    when the sun is at -6 degrees and sunrise/sunset.
+    This method defines twilight as being between civil dawn/dusk and sunrise/sunset.
 
     Args:
         observer:   Observer to calculate twilight for
@@ -1071,7 +1070,7 @@ def twilight(
     if date is None:
         date = today(tzinfo)  # type: ignore
 
-    start = time_of_transit(observer, date, 90 + 6, direction,).astimezone(
+    start = time_of_transit(observer, date, 90 + Depression.CIVIL.value, direction,).astimezone(
         tzinfo  # type: ignore
     )
     if direction == SunDirection.RISING:


### PR DESCRIPTION
Hello,

when using the astral package I realized there is an error in the documentation of the night function: The documentation was stating the night function to calculate the time between astronomical dusk and dawn, which would be when the sun is at -18°, but in the code the civil dusk and dawn, when the sun is at -6°, was used.
Furthermore, in the documentation of the twilight function the civil dawn/dusk was described by "when the sun is at -6 degrees" which is the same but overcomplicated.
Finally, the code was using hard-coded degree values instead of the values from the `Depression` enumeration which makes it easier understandable.

All tests are passing.

Best regards,
Triple-S