### PR TITLE
Remove spurious pytest-runner dependency from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ isolated_build = True
 deps =
     freezegun
     pytest
-    pytest-runner
 commands =
     pytest
 


### PR DESCRIPTION
It has been [deprecated upstream](https://github.com/pytest-dev/pytest-runner/tree/v6.0.1?tab=readme-ov-file#deprecation-notice) for some time, and the project is now archived. It is not required for running the tests via tox anyway, so nothing seems to be lost by removing the dependency.